### PR TITLE
set min lines on Textbox

### DIFF
--- a/examples/sqlite_chat.py
+++ b/examples/sqlite_chat.py
@@ -223,7 +223,11 @@ def main(csv_file: str):
                 schema_box = gr.Dataframe(value=schema)
 
         query_text_box = gr.Textbox(value=initial_query, label='Last Query')
-        explanation_text_box = gr.Textbox(value=initial_explanation, label='Explanation')
+        explanation_text_box = gr.Textbox(
+            value=initial_explanation, label='Explanation',
+            lines=5,
+            max_lines=20
+        )
         chatbot = gr.Chatbot()
         question = gr.Textbox(
             value=DEFAULT_QUESTION, label='Ask a question about the data')


### PR DESCRIPTION
The way this seems to work is that the Textbox auto resizes to fit the input, but that doesn't quite work when zoomed in. The default min and max lines is 1 and 20, this PR changes it to 5 and 20. Min lines of 5 results in some extra space but seems to give more room to zoom in.

https://www.gradio.app/docs/textbox

I noticed in the CSS that the textareas can scroll and resize, but this is disabled and there doesn't seem to be an easy way to re-enable it in code.