### PR TITLE
fix bank agent eval question

### DIFF
--- a/examples/bank_agent.py
+++ b/examples/bank_agent.py
@@ -2,7 +2,6 @@
 Example of using an LLM to chat with a database.
 """
 
-import os
 import sys
 import logging
 import sqlite3
@@ -14,7 +13,6 @@ from neosophia.llmtools import openaiapi as openai, tools
 from neosophia.agents.react import make_react_agent
 from neosophia.agents.helpers import check_question
 from neosophia.db.sqlite_utils import get_db_creation_sql
-from examples import project
 
 from examples import project
 

--- a/examples/bank_agent_eval.py
+++ b/examples/bank_agent_eval.py
@@ -76,32 +76,33 @@ def main():
 
     systems = {
         'agent (simple)': build_agent(model_name='gpt-4-0613', simple=True),
-        'agent (simple, patched)': patch_agent(
-            build_agent(model_name='gpt-4-0613', simple=True),
-            lambda: patch_format_message_simple(format_message_patched),
-            undo_patch_format_message_simple
-        ),
-        'agent (react)': build_agent(model_name='gpt-4-0613', simple=False),
+        # 'agent (simple, patched)': patch_agent(
+        #     build_agent(model_name='gpt-4-0613', simple=True),
+        #     lambda: patch_format_message_simple(format_message_patched),
+        #     undo_patch_format_message_simple
+        # ),
+        # 'agent (react)': build_agent(model_name='gpt-4-0613', simple=False),
         'agent (simple, 3.5)': build_agent(model_name='gpt-3.5-turbo-0613', simple=True),
     }
 
     qs_and_evals = [
+        # (
+        #     'Who most recently opened a checking account?',
+        #     lambda x: 'John Thompson' in x
+        # ),
         (
-            'Who most recently opened a checking account?',
-            lambda x: 'John Thompson' in x
+            # 'How many people have opened a savings account in the last year?',
+            'How many people have opened a savings account between 2022-08-01 and 2023-08-01?',
+            lambda x: '32' in words(x)
         ),
-        (
-            'How many people have opened a savings account in the last year?',
-            lambda x: '34' in words(x)
-        ),
-        (
-            'How many products does the person who most recently opened a mortgage have?',
-            lambda x: '2' in words(x)
-        ),
-        (
-            'Which customer has the highest interest rate on their credit card, and what is that interest rate?',
-            lambda x: ('Edith Nelson' in x or '100389' in x) and ('0.3' in words(x) or '30%' in words(x))
-        )
+        # (
+        #     'How many products does the person who most recently opened a mortgage have?',
+        #     lambda x: '2' in words(x)
+        # ),
+        # (
+        #     'Which customer has the highest interest rate on their credit card, and what is that interest rate?',
+        #     lambda x: ('Edith Nelson' in x or '100389' in x) and ('0.3' in words(x) or '30%' in words(x))
+        # )
     ]
 
     results = eval_systems(systems, qs_and_evals, n_runs)

--- a/examples/bank_agent_eval.py
+++ b/examples/bank_agent_eval.py
@@ -26,7 +26,7 @@ def main():
     """main program"""
 
     # configuration
-    n_runs = 3
+    n_runs = 10
 
     # setup
     api_key = oaiapi.load_api_key(project.OPENAI_API_KEY_FILE_PATH)
@@ -76,33 +76,32 @@ def main():
 
     systems = {
         'agent (simple)': build_agent(model_name='gpt-4-0613', simple=True),
-        # 'agent (simple, patched)': patch_agent(
-        #     build_agent(model_name='gpt-4-0613', simple=True),
-        #     lambda: patch_format_message_simple(format_message_patched),
-        #     undo_patch_format_message_simple
-        # ),
-        # 'agent (react)': build_agent(model_name='gpt-4-0613', simple=False),
+        'agent (simple, patched)': patch_agent(
+            build_agent(model_name='gpt-4-0613', simple=True),
+            lambda: patch_format_message_simple(format_message_patched),
+            undo_patch_format_message_simple
+        ),
+        'agent (react)': build_agent(model_name='gpt-4-0613', simple=False),
         'agent (simple, 3.5)': build_agent(model_name='gpt-3.5-turbo-0613', simple=True),
     }
 
     qs_and_evals = [
-        # (
-        #     'Who most recently opened a checking account?',
-        #     lambda x: 'John Thompson' in x
-        # ),
         (
-            # 'How many people have opened a savings account in the last year?',
-            'How many people have opened a savings account between 2022-08-01 and 2023-08-01?',
+            'Who most recently opened a checking account?',
+            lambda x: 'John Thompson' in x
+        ),
+        (
+            'How many unique people opened a savings account between 2022-08-01 and 2023-08-01?',
             lambda x: '32' in words(x)
         ),
-        # (
-        #     'How many products does the person who most recently opened a mortgage have?',
-        #     lambda x: '2' in words(x)
-        # ),
-        # (
-        #     'Which customer has the highest interest rate on their credit card, and what is that interest rate?',
-        #     lambda x: ('Edith Nelson' in x or '100389' in x) and ('0.3' in words(x) or '30%' in words(x))
-        # )
+        (
+            'How many products does the person who most recently opened a mortgage have?',
+            lambda x: '2' in words(x)
+        ),
+        (
+            'Which customer has the highest interest rate on their credit card, and what is that interest rate?',
+            lambda x: ('Edith Nelson' in x or '100389' in x) and ('0.3' in words(x) or '30%' in words(x))
+        )
     ]
 
     results = eval_systems(systems, qs_and_evals, n_runs)


### PR DESCRIPTION
The old question about accounts opened in the past year is problematic because the answer changes with today's date.

Initial new question: "How many people have opened a savings account between 2022-08-01 and 2023-08-01?"

A naive query only looks at distinct account numbers:

    SELECT COUNT(DISTINCT account_number)
    FROM savings_account
    WHERE account_open_date BETWEEN '2022-08-01' AND '2023-08-01'

34 unique savings account were opened. But we want unique people:

    SELECT COUNT(DISTINCT guid)
    FROM savings_account
    JOIN products ON savings_account.account_number = products.account_number
    WHERE account_open_date BETWEEN '2022-08-01' AND '2023-08-01'

32 people!

Update 1:

Ran a comparison between "How many people have opened..." and "How many unique people opened...". Results suggest that the both GPT-4 and GPT-3.5 do better with the second question. Results for 10 runs:

![image](https://github.com/prolego-team/neo-sophia/assets/10505370/e58e8028-3cb9-4e12-969e-d5a95b09adc0)

For now, choosing "How many unique people" as the question but it is pretty interesting to note the difference in performance.

Update 2:

Complete results for 10 runs across all systems and questions:

<img width="709" alt="image" src="https://github.com/prolego-team/neo-sophia/assets/10505370/617d2492-499c-49ae-b1c0-d40f3e8e038c">

![image](https://github.com/prolego-team/neo-sophia/assets/10505370/3c09f85e-849c-4591-b4b2-6e7be6bf934e)

